### PR TITLE
feat: account login

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,7 @@ gem "redis", ">= 4.0.1"
 # gem "kredis"
 
 # Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]
-# gem "bcrypt", "~> 3.1.7"
+gem "bcrypt", "~> 3.1.7"
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem "tzinfo-data", platforms: %i[windows jruby]
@@ -75,3 +75,6 @@ group :test do
   gem "selenium-webdriver"
   gem "shoulda", "5.0.0.rc1"
 end
+
+gem "rodauth-i18n", "~> 0.7.1"
+gem "rodauth-rails", "~> 1.13"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,8 +77,12 @@ GEM
       tzinfo (~> 2.0)
     addressable (2.8.6)
       public_suffix (>= 2.0.2, < 6.0)
+    after_commit_everywhere (1.3.1)
+      activerecord (>= 4.2)
+      activesupport
     ast (2.4.2)
     base64 (0.2.0)
+    bcrypt (3.1.20)
     bigdecimal (3.1.5)
     bindex (0.8.1)
     bootsnap (1.17.0)
@@ -225,6 +229,24 @@ GEM
     reline (0.4.1)
       io-console (~> 0.5)
     rexml (3.2.6)
+    roda (3.76.0)
+      rack
+    rodauth (2.33.0)
+      roda (>= 2.6.0)
+      sequel (>= 4)
+    rodauth-i18n (0.7.1)
+      i18n (~> 1.0)
+      rodauth (~> 2.19)
+    rodauth-model (0.2.1)
+      rodauth (~> 2.0)
+    rodauth-rails (1.13.0)
+      bcrypt
+      railties (>= 5.0, < 8)
+      roda (~> 3.73)
+      rodauth (~> 2.30)
+      rodauth-model (~> 0.2)
+      sequel-activerecord_connection (~> 1.1)
+      tilt
     rubocop (1.59.0)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
@@ -258,6 +280,12 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
+    sequel (5.76.0)
+      bigdecimal
+    sequel-activerecord_connection (1.3.1)
+      activerecord (>= 4.2, < 8)
+      after_commit_everywhere (~> 1.1)
+      sequel (~> 5.38)
     shoulda (5.0.0.rc1)
       shoulda-context (~> 2.0)
       shoulda-matchers (~> 5.0)
@@ -275,6 +303,7 @@ GEM
       railties (>= 6.0.0)
     stringio (3.1.0)
     thor (1.3.0)
+    tilt (2.3.0)
     timeout (0.4.1)
     turbo-rails (1.5.0)
       actionpack (>= 6.0.0)
@@ -306,6 +335,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  bcrypt (~> 3.1.7)
   bootsnap
   capybara
   debug
@@ -317,6 +347,8 @@ DEPENDENCIES
   puma (>= 5.0)
   rails (~> 7.1.2)
   redis (>= 4.0.1)
+  rodauth-i18n (~> 0.7.1)
+  rodauth-rails (~> 1.13)
   rubocop
   rubocop-minitest
   rubocop-performance

--- a/app/assets/stylesheets/animations.css
+++ b/app/assets/stylesheets/animations.css
@@ -1,0 +1,11 @@
+@keyframes appear-then-fade {
+  0%,
+  100% {
+    opacity: 0
+  }
+
+  5%,
+  60% {
+    opacity: 1
+  }
+}

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -49,3 +49,7 @@ table.pure-table.compact-table th {
 .text-right {
   text-align: right;
 }
+
+.pure-g.centered-grid {
+  justify-content: center;
+}

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -41,3 +41,11 @@ table.pure-table.compact-table td,
 table.pure-table.compact-table th {
   padding: 0.45em 0.27em;
 }
+
+.text-center {
+  text-align: center;
+}
+
+.text-right {
+  text-align: right;
+}

--- a/app/assets/stylesheets/colors.css
+++ b/app/assets/stylesheets/colors.css
@@ -1,3 +1,6 @@
 :root {
   --warning: red;
+  --sidebar: rgb(61, 79, 93);
+  --sidebarfont: white;
+  --sidebar-link-hover: rgb(51, 58, 78)
 }

--- a/app/assets/stylesheets/colors.css
+++ b/app/assets/stylesheets/colors.css
@@ -1,6 +1,0 @@
-:root {
-  --warning: red;
-  --sidebar: rgb(61, 79, 93);
-  --sidebarfont: white;
-  --sidebar-link-hover: rgb(51, 58, 78)
-}

--- a/app/assets/stylesheets/flash.css
+++ b/app/assets/stylesheets/flash.css
@@ -1,0 +1,24 @@
+.flash {
+  position: fixed;
+  bottom: 0.5rem;
+  left: 50%;
+  transform: translateX(-50%);
+
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-s);
+
+  max-width: 100%;
+  width: max-content;
+  padding: 0 var(--space-m);
+
+  & .__message {
+    font-size: var(--font-size-s);
+    color: var(--color-white);
+    padding: var(--space-xs) var(--space-m);
+    background-color: var(--color-dark);
+    border-radius: 999px;
+    animation: appear-then-fade 4s both;
+  }
+}

--- a/app/assets/stylesheets/icons.css
+++ b/app/assets/stylesheets/icons.css
@@ -1,0 +1,3 @@
+span[class*="material-symbols-"] {
+  font-size: 34px;
+}

--- a/app/assets/stylesheets/layout.css
+++ b/app/assets/stylesheets/layout.css
@@ -1,10 +1,20 @@
 #layout {
+  position: relative;
   padding: 0;
+  right: 0;
 }
 
 .sidebar {
-  background: rgb(61, 79, 93);
+  background: var(--sidebar);
   color: #fff;
+}
+
+.sidebar span[class*="material-symbols-"]{
+  color: var(--sidebarfont);
+}
+
+.sidebar .pure-menu-link:hover {
+  background-color: var(--sidebar-link-hover);
 }
 
 .header {
@@ -72,6 +82,10 @@
   background: none;
 }
 
+.menu-lg-screen {
+  margin-top: auto;
+}
+
 @media (min-width: 48em) {
   .content {
     padding: 2em 3em 0;
@@ -96,5 +110,17 @@
 
   .footer {
     text-align: center;
+  }
+
+  .nav-menu-wrapper {
+    display: flex;
+    flex-direction: column;
+    min-height: 100vh;
+  }
+}
+
+@media (max-width: 48em) {
+  .menu-lg-screen {
+    display: none;
   }
 }

--- a/app/assets/stylesheets/login.css
+++ b/app/assets/stylesheets/login.css
@@ -1,0 +1,6 @@
+.login-content {
+  margin-top: 1vh;
+  margin-left: auto;
+  margin-right: auto;
+  max-width: 768px;
+}

--- a/app/assets/stylesheets/menu.css
+++ b/app/assets/stylesheets/menu.css
@@ -1,0 +1,75 @@
+#menu {
+  margin-right: -150px;
+  width: 150px;
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 1000;
+  overflow-y: auto;
+}
+
+.app-menu {
+  background-color: var(--sidebar);
+  color: var(--sidebarfont);
+}
+
+.app-menu a {
+  color: inherit;
+}
+
+.app-menu .pure-menu-heading {
+  color: inherit;
+}
+
+
+#toggle-menu {
+  display: none;
+}
+
+#layout.active #menu {
+  right: 150px;
+  width: 150px;
+}
+
+#layout.active #toggle-menu {
+  right: 150px;
+}
+
+#layout,
+#menu,
+#toggle-menu {
+  transition: all 0.2s ease-in;
+}
+
+@media (max-width: 48em) {
+  #toggle-menu {
+    position: fixed;
+    display: block;
+    top: 0;
+    right: 0;
+    z-index: 10;
+    width: 2em;
+    height: auto;
+  }
+}
+
+@media (min-width: 48em) {
+  #menu {
+    right: 150;
+  }
+}
+
+@media (max-width: 48em) {
+
+  /* Only apply this when the window is small. Otherwise, the following
+    case results in extra padding on the left:
+        * Make the window small.
+        * Tap the menu to trigger the active state.
+        * Make the window large again.
+    */
+  #layout.active {
+    position: relative;
+    right: 150px;
+  }
+}

--- a/app/assets/stylesheets/scrollable_table.css
+++ b/app/assets/stylesheets/scrollable_table.css
@@ -1,6 +1,6 @@
 .scrollable-table {
   overflow-y: auto;
-  height: 70vh;
+  max-height: 70vh;
 }
 
 .scrollable-table > table {

--- a/app/assets/stylesheets/variables.css
+++ b/app/assets/stylesheets/variables.css
@@ -1,0 +1,29 @@
+:root {
+  --warning: red;
+  --sidebar: rgb(61, 79, 93);
+  --sidebarfont: white;
+  --sidebar-link-hover: rgb(51, 58, 78);
+  --color-white: hsl(0, 0%, 100%);
+  --color-text-header: hsl(0, 1%, 16%);
+  --color-dark: var(--color-text-header);
+
+  --space-xxxs: 0.25rem;
+  --space-xxs: 0.375rem;
+  --space-xs: 0.5rem;
+  --space-s: 0.75rem;
+  --space-m: 1rem;
+  --space-l: 1.5rem;
+  --space-xl: 2rem;
+  --space-xxl: 2.5rem;
+  --space-xxxl: 3rem;
+  --space-xxxxl: 4rem;
+
+  --font-size-xs: 0.75rem;
+  --font-size-s: 0.875rem;
+  --font-size-m: 1rem;
+  --font-size-l: 1.125rem;
+  --font-size-xl: 1.25rem;
+  --font-size-xxl: 1.5rem;
+  --font-size-xxxl: 2rem;
+  --font-size-xxxxl: 2.5rem;
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,14 @@
 # frozen_string_literal: true
 
+# Main application controller, define here methods to inherit to all sub controllers
 class ApplicationController < ActionController::Base
+  private
+
+  def current_account
+    rodauth.rails_account
+  end
+
+  def authenticate
+    rodauth.require_account # redirect to login page if not authenticated
+  end
 end

--- a/app/controllers/profile_controller.rb
+++ b/app/controllers/profile_controller.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# show profile for current logged account
+class ProfileController < ApplicationController
+  before_action :authenticate
+
+  def show; end
+end

--- a/app/controllers/rodauth_controller.rb
+++ b/app/controllers/rodauth_controller.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+# Used by Rodauth for rendering views, CSRF protection, and running any registered action callbacks and
+# rescue_from handlers
+class RodauthController < ApplicationController
+  layout "authentication"
+end

--- a/app/javascript/controllers/removal_controller.js
+++ b/app/javascript/controllers/removal_controller.js
@@ -1,0 +1,9 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Remove an element
+// Connects to data-controller="removal"
+export default class extends Controller {
+  remove() {
+    this.element.remove()
+  }
+}

--- a/app/javascript/controllers/toggle_controller.js
+++ b/app/javascript/controllers/toggle_controller.js
@@ -1,0 +1,11 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="toggle"
+export default class extends Controller {
+  static targets = [ "element" ]
+  static classes = [ "toggle" ]
+
+  toggle() {
+    this.elementTargets.forEach((element) => element.classList.toggle(this.toggleClass))
+  }
+}

--- a/app/mailers/rodauth_mailer.rb
+++ b/app/mailers/rodauth_mailer.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+# Mailer for rodauth features
+class RodauthMailer < ApplicationMailer
+  default to: -> { @rodauth.email_to }, from: -> { @rodauth.email_from }
+
+  def verify_account(name, account_id, key)
+    @rodauth = rodauth(name, account_id) { @verify_account_key_value = key }
+    @account = @rodauth.rails_account
+
+    mail subject: @rodauth.email_subject_prefix + @rodauth.verify_account_email_subject
+  end
+
+  def reset_password(name, account_id, key)
+    @rodauth = rodauth(name, account_id) { @reset_password_key_value = key }
+    @account = @rodauth.rails_account
+
+    mail subject: @rodauth.email_subject_prefix + @rodauth.reset_password_email_subject
+  end
+
+  def verify_login_change(name, account_id, key)
+    @rodauth = rodauth(name, account_id) { @verify_login_change_key_value = key }
+    @account = @rodauth.rails_account
+    @new_email = @account.login_change_key.login
+
+    mail to: @new_email, subject: @rodauth.email_subject_prefix + @rodauth.verify_login_change_email_subject
+  end
+
+  def password_changed(name, account_id)
+    @rodauth = rodauth(name, account_id)
+    @account = @rodauth.rails_account
+
+    mail subject: @rodauth.email_subject_prefix + @rodauth.password_changed_email_subject
+  end
+
+  # def reset_password_notify(name, account_id)
+  #   @rodauth = rodauth(name, account_id)
+  #   @account = @rodauth.rails_account
+
+  #   mail subject: @rodauth.email_subject_prefix + @rodauth.reset_password_notify_email_subject
+  # end
+
+  # def email_auth(name, account_id, key)
+  #   @rodauth = rodauth(name, account_id) { @email_auth_key_value = key }
+  #   @account = @rodauth.rails_account
+
+  #   mail subject: @rodauth.email_subject_prefix + @rodauth.email_auth_email_subject
+  # end
+
+  # def unlock_account(name, account_id, key)
+  #   @rodauth = rodauth(name, account_id) { @unlock_account_key_value = key }
+  #   @account = @rodauth.rails_account
+
+  #   mail subject: @rodauth.email_subject_prefix + @rodauth.unlock_account_email_subject
+  # end
+
+  private
+
+  def rodauth(name, account_id, &block)
+    instance = RodauthApp.rodauth(name).allocate
+    instance.instance_eval { @account = account_ds(account_id).first! }
+    instance.instance_eval(&block) if block
+    instance
+  end
+end

--- a/app/misc/rodauth_app.rb
+++ b/app/misc/rodauth_app.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# Rodaauth middleware configuration
+class RodauthApp < Rodauth::Rails::App
+  # primary configuration
+  configure RodauthMain
+
+  # secondary configuration
+  # configure RodauthAdmin, :admin
+
+  route do |r|
+    rodauth.load_memory # autologin remembered users
+
+    r.rodauth # route rodauth requests
+
+    # ==> Authenticating requests
+    # Call `rodauth.require_account` for requests that you want to
+    # require authentication for. For example:
+    #
+    # # authenticate /dashboard/* and /account/* requests
+    # if r.path.start_with?("/dashboard") || r.path.start_with?("/account")
+    #   rodauth.require_account
+    # end
+
+    # ==> Secondary configurations
+    # r.rodauth(:admin) # route admin rodauth requests
+  end
+end

--- a/app/misc/rodauth_main.rb
+++ b/app/misc/rodauth_main.rb
@@ -167,7 +167,7 @@ class RodauthMain < Rodauth::Rails::Auth
 
     # ==> Redirects
     # Redirect to home page after logout.
-    logout_redirect "/"
+    logout_redirect "/login"
 
     # Redirect to wherever login redirects to after account verification.
     verify_account_redirect { login_redirect }

--- a/app/misc/rodauth_main.rb
+++ b/app/misc/rodauth_main.rb
@@ -39,7 +39,7 @@ class RodauthMain < Rodauth::Rails::Auth
 
     # The secret key used for hashing public-facing tokens for various features.
     # Defaults to Rails `secret_key_base`, but you can use your own secret key.
-    # hmac_secret "9da2c19ff1797e5182574396d3eca460d4c3db639d739eeb849b6bfb60884f9581d624406a52a03b3bccf5a8f2eb410337054cbb6f3bcf3a7062a0edafac0632"
+    # hmac_secret "9da2c19ff1797e5182574396d3eca460d4c3db639d739eeb849b6bfb60884f9581d624406a52a03b3bccf5a8f2eb41033705"
 
     # Use path prefix for all routes.
     # prefix "/auth"
@@ -111,7 +111,8 @@ class RodauthMain < Rodauth::Rails::Auth
     # flash_error_key :error # default is :alert
 
     # Override default flash messages.
-    # create_account_notice_flash "Your account has been created. Please verify your account by visiting the confirmation link sent to your email address."
+    # create_account_notice_flash "Your account has been created. Please verify your account by visiting the
+    # confirmation link sent to your email address."
     # require_login_error_flash "Login is required for accessing this page"
     # login_notice_flash nil
 
@@ -120,7 +121,8 @@ class RodauthMain < Rodauth::Rails::Auth
     # no_matching_login_message "user with this email address doesn't exist"
     # already_an_account_with_this_login_message "user with this email address already exists"
     # password_too_short_message { "needs to have at least #{password_minimum_length} characters" }
-    # login_does_not_meet_requirements_message { "invalid email#{", #{login_requirement_message}" if login_requirement_message}" }
+    # login_does_not_meet_requirements_message {
+    # "invalid email#{", #{login_requirement_message}" if login_requirement_message}" }
 
     # Passwords shorter than 8 characters are considered weak according to OWASP.
     password_minimum_length 8

--- a/app/misc/rodauth_main.rb
+++ b/app/misc/rodauth_main.rb
@@ -1,0 +1,188 @@
+# frozen_string_literal: true
+
+require "sequel/core"
+
+# Rodaauth main configuration
+class RodauthMain < Rodauth::Rails::Auth
+  configure do
+    # List of authentication features that are loaded.
+    enable :create_account,
+           :verify_account,
+           :verify_account_grace_period,
+           :login,
+           :logout,
+           :remember,
+           :reset_password,
+           :change_password,
+           :change_password_notify,
+           :change_login,
+           :verify_login_change,
+           :close_account,
+           :i18n
+
+    # See the Rodauth documentation for the list of available config options:
+    # http://rodauth.jeremyevans.net/documentation.html
+
+    # ==> General
+    # Initialize Sequel and have it reuse Active Record's database connection.
+    db Sequel.postgres(extensions: :activerecord_connection, keep_reference: false)
+
+    # Avoid DB query that checks accounts table schema at boot time.
+    convert_token_id_to_integer? true
+
+    # Change prefix of table and foreign key column names from default "account"
+    # accounts_table :users
+    # verify_account_table :user_verification_keys
+    # verify_login_change_table :user_login_change_keys
+    # reset_password_table :user_password_reset_keys
+    # remember_table :user_remember_keys
+
+    # The secret key used for hashing public-facing tokens for various features.
+    # Defaults to Rails `secret_key_base`, but you can use your own secret key.
+    # hmac_secret "9da2c19ff1797e5182574396d3eca460d4c3db639d739eeb849b6bfb60884f9581d624406a52a03b3bccf5a8f2eb410337054cbb6f3bcf3a7062a0edafac0632"
+
+    # Use path prefix for all routes.
+    # prefix "/auth"
+
+    # Specify the controller used for view rendering, CSRF, and callbacks.
+    rails_controller { RodauthController }
+
+    # Make built-in page titles accessible in your views via an instance variable.
+    title_instance_variable :@page_title
+
+    # Store account status in an integer column without foreign key constraint.
+    account_status_column :status
+
+    # Store password hash in a column instead of a separate table.
+    account_password_hash_column :password_hash
+
+    # Set password when creating account instead of when verifying.
+    verify_account_set_password? false
+
+    # Change some default param keys.
+    login_param "email"
+    login_confirm_param "email-confirm"
+    # password_confirm_param "confirm_password"
+
+    # Redirect back to originally requested location after authentication.
+    # login_return_to_requested_location? true
+    # two_factor_auth_return_to_requested_location? true # if using MFA
+
+    # Autologin the user after they have reset their password.
+    # reset_password_autologin? true
+
+    # Delete the account record when the user has closed their account.
+    # delete_account_on_close? true
+
+    # Redirect to the app from login and registration pages if already logged in.
+    # already_logged_in { redirect login_redirect }
+
+    # ==> Emails
+    # Use a custom mailer for delivering authentication emails.
+    create_reset_password_email do
+      RodauthMailer.reset_password(self.class.configuration_name, account_id, reset_password_key_value)
+    end
+    create_verify_account_email do
+      RodauthMailer.verify_account(self.class.configuration_name, account_id, verify_account_key_value)
+    end
+    create_verify_login_change_email do |_login|
+      RodauthMailer.verify_login_change(self.class.configuration_name, account_id, verify_login_change_key_value)
+    end
+    create_password_changed_email do
+      RodauthMailer.password_changed(self.class.configuration_name, account_id)
+    end
+    # create_reset_password_notify_email do
+    #   RodauthMailer.reset_password_notify(self.class.configuration_name, account_id)
+    # end
+    # create_email_auth_email do
+    #   RodauthMailer.email_auth(self.class.configuration_name, account_id, email_auth_key_value)
+    # end
+    # create_unlock_account_email do
+    #   RodauthMailer.unlock_account(self.class.configuration_name, account_id, unlock_account_key_value)
+    # end
+    send_email do |email|
+      # queue email delivery on the mailer after the transaction commits
+      db.after_commit { email.deliver_later }
+    end
+
+    # ==> Flash
+    # Match flash keys with ones already used in the Rails app.
+    # flash_notice_key :success # default is :notice
+    # flash_error_key :error # default is :alert
+
+    # Override default flash messages.
+    # create_account_notice_flash "Your account has been created. Please verify your account by visiting the confirmation link sent to your email address."
+    # require_login_error_flash "Login is required for accessing this page"
+    # login_notice_flash nil
+
+    # ==> Validation
+    # Override default validation error messages.
+    # no_matching_login_message "user with this email address doesn't exist"
+    # already_an_account_with_this_login_message "user with this email address already exists"
+    # password_too_short_message { "needs to have at least #{password_minimum_length} characters" }
+    # login_does_not_meet_requirements_message { "invalid email#{", #{login_requirement_message}" if login_requirement_message}" }
+
+    # Passwords shorter than 8 characters are considered weak according to OWASP.
+    password_minimum_length 8
+    # bcrypt has a maximum input length of 72 bytes, truncating any extra bytes.
+    password_maximum_bytes 72
+
+    # Custom password complexity requirements (alternative to password_complexity feature).
+    # password_meets_requirements? do |password|
+    #   super(password) && password_complex_enough?(password)
+    # end
+    # auth_class_eval do
+    #   def password_complex_enough?(password)
+    #     return true if password.match?(/\d/) && password.match?(/[^a-zA-Z\d]/)
+    #     set_password_requirement_error_message(:password_simple, "requires one number and one special character")
+    #     false
+    #   end
+    # end
+
+    # ==> Remember Feature
+    # Remember all logged in users.
+    after_login { remember_login }
+
+    # Or only remember users that have ticked a "Remember Me" checkbox on login.
+    # after_login { remember_login if param_or_nil("remember") }
+
+    # Extend user's remember period when remembered via a cookie
+    extend_remember_deadline? true
+
+    # ==> Hooks
+    # Validate custom fields in the create account form.
+    # before_create_account do
+    #   throw_error_status(422, "name", "must be present") if param("name").empty?
+    # end
+
+    # Perform additional actions after the account is created.
+    # after_create_account do
+    #   Profile.create!(account_id: account_id, name: param("name"))
+    # end
+
+    # Do additional cleanup after the account is closed.
+    # after_close_account do
+    #   Profile.find_by!(account_id: account_id).destroy
+    # end
+
+    # ==> Redirects
+    # Redirect to home page after logout.
+    logout_redirect "/"
+
+    # Redirect to wherever login redirects to after account verification.
+    verify_account_redirect { login_redirect }
+
+    # Redirect to login page after password reset.
+    reset_password_redirect { login_path }
+
+    # Ensure requiring login follows login route changes.
+    require_login_redirect { login_path }
+
+    # ==> Deadlines
+    # Change default deadlines for some actions.
+    # verify_account_grace_period 3.days.to_i
+    # reset_password_deadline_interval Hash[hours: 6]
+    # verify_login_change_deadline_interval Hash[days: 2]
+    # remember_deadline_interval Hash[days: 30]
+  end
+end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+# Manange accounts for this app
+class Account < ApplicationRecord
+  include Rodauth::Model(RodauthMain)
+  enum :status, unverified: 1, verified: 2, closed: 3
+end

--- a/app/views/application/_menu.html.erb
+++ b/app/views/application/_menu.html.erb
@@ -8,8 +8,8 @@
     </li>
     <li class="pure-menu-item">
       <%= link_to translate("links.profile"),
-                   rodauth.remember_route,
-                   class: "pure-menu-link" %>
+                  profile_path,
+                  class: "pure-menu-link" %>
     </li>
   <% end %>
 </ul>

--- a/app/views/application/_menu.html.erb
+++ b/app/views/application/_menu.html.erb
@@ -1,10 +1,15 @@
 <ul class="pure-menu-list">
-  <li class="pure-menu-item">
-    <% if rodauth.logged_in? %>
-      <%= link_to rodauth.logout_button,
-                  rodauth.logout_path,
-                  class: "pure-menu-link",
-                  data: { turbo_method: :post } %>
-    <% end %>
-  </li>
+  <% if rodauth.logged_in? %>
+    <li class="pure-menu-item">
+        <%= link_to rodauth.logout_button,
+                    rodauth.logout_path,
+                    class: "pure-menu-link",
+                    data: { turbo_method: :post } %>
+    </li>
+    <li class="pure-menu-item">
+      <%= link_to translate("links.profile"),
+                   rodauth.remember_route,
+                   class: "pure-menu-link" %>
+    </li>
+  <% end %>
 </ul>

--- a/app/views/application/_menu.html.erb
+++ b/app/views/application/_menu.html.erb
@@ -1,0 +1,10 @@
+<ul class="pure-menu-list">
+  <li class="pure-menu-item">
+    <% if rodauth.logged_in? %>
+      <%= link_to rodauth.logout_button,
+                  rodauth.logout_path,
+                  class: "pure-menu-link",
+                  data: { turbo_method: :post } %>
+    <% end %>
+  </li>
+</ul>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -55,16 +55,9 @@
         </div>
       </div>
       <div class="content pure-u-1 pure-u-md-4-5">
-        <%  if notice %>
-          <div class="notice">
-             <%= notice %>
-          </div>
-        <% end %>
-        <% if alert %>
-          <div class="warning">
-           <%= alert %>
-          </div>
-        <% end %>
+         <div class="flash">
+          <%= render "shared/flash" %>
+         </div>
         <main>
           <%= yield %>
         </main>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>Presupuestop</title>
+    <title> <%= @page_title || "Presupuestop" %> </title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
@@ -13,25 +13,58 @@
                             "data-turbo-track": "reload" %>
     <%= stylesheet_link_tag "https://cdn.jsdelivr.net/npm/purecss@3.0.0/build/grids-responsive-min.css",
                             "data-turbo-track": "reload" %>
+    <%= stylesheet_link_tag "https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined",
+                            "data-turob-track": "reload" %>
     <%= javascript_importmap_tags %>
   </head>
 
   <body>
-    <div id="layout" class="pure-g">
+    <div id="layout"
+         class="pure-g"
+         data-controller="toggle"
+         data-toggle-toggle-class="active"
+         data-toggle-target="element">
       <div class="sidebar pure-u-1 pure-u-md-1-5">
-        <header class="header">
+        <div class="nav-menu-wrapper">
+          <header class="header">
           <h2 class="brand-title"> <%= t("titles.expenses") %></h1>
           <h3 class="brand-tagline"> <%= t("descriptions.expenses")%> </h2>
+          <a id="toggle-menu"
+             href="javascript:void(0);"
+             data-action="click->toggle#toggle">
+            <span class="material-symbols-outlined">menu</span>
+          </a>
+          <div id="menu" class="app-menu pure-menu" data-toggle-target="element">
+            <div class="pure-menu-heading">
+             MENU
+            </div>
+            <%= render "menu" %>
+          </div>
           <nav class="nav">
             <ul class="nav-list">
               <li class="nav-item">
                 <%= link_to t("links.expenses"), expenses_path, class: "pure-button" %>
               </li>
             </ul>
-        </header>
-        </nav>
+          </nav>
+          </header>
+
+          <div class="menu-lg-screen app-menu pure-menu text-right">
+            <%= render "menu" %>
+          </div>
+        </div>
       </div>
       <div class="content pure-u-1 pure-u-md-4-5">
+        <%  if notice %>
+          <div class="notice">
+             <%= notice %>
+          </div>
+        <% end %>
+        <% if alert %>
+          <div class="warning">
+           <%= alert %>
+          </div>
+        <% end %>
         <main>
           <%= yield %>
         </main>
@@ -49,4 +82,12 @@
       </div>
     </div>
   </body>
+
+  <script>
+    function myFunction() {
+      var x = document.getElementById("menu");
+      x.classList.toggle("active");
+      document.getElementById("layout").classList.toggle("active")
+    }
+  </script>
 </html>

--- a/app/views/layouts/authentication.html.erb
+++ b/app/views/layouts/authentication.html.erb
@@ -15,10 +15,12 @@
                             "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>
   </head>
-  <body class="pure-g">
+  <body class="pure-g centered-grid">
     <div class="flash">
       <%= render "shared/flash" %>
     </div>
-    <%= yield %>
+    <div class="pure-u-1-3">
+      <%= yield %>
+    </div>
   </body>
 </html>

--- a/app/views/layouts/authentication.html.erb
+++ b/app/views/layouts/authentication.html.erb
@@ -16,16 +16,9 @@
     <%= javascript_importmap_tags %>
   </head>
   <body class="pure-g">
-    <% if notice %>
-      <div class="notice">
-        <%= notice %>
-      </div>
-    <% end %>
-    <% if alert %>
-      <div class="alert">
-      <%= alert %>
-      </div>
-    <% end %>
+    <div class="flash">
+      <%= render "shared/flash" %>
+    </div>
     <%= yield %>
   </body>
 </html>

--- a/app/views/layouts/authentication.html.erb
+++ b/app/views/layouts/authentication.html.erb
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title> <%= @page_title || "Presupuestop" %> </title>
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <%= csrf_meta_tags %>
+    <%= csp_meta_tag %>
+
+    <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
+    <%= stylesheet_link_tag "https://cdn.jsdelivr.net/npm/purecss@3.0.0/build/pure-min.css",
+                            integrity: "sha384-X38yfunGUhNzHpBaEBsWLO+A0HDYOQi8ufWDkZ0k9e0eXz/tH3II7uKZ9msv++Ls",
+                            crossorigin: "anonymous",
+                            "data-turbo-track": "reload" %>
+    <%= stylesheet_link_tag "https://cdn.jsdelivr.net/npm/purecss@3.0.0/build/grids-responsive-min.css",
+                            "data-turbo-track": "reload" %>
+    <%= javascript_importmap_tags %>
+  </head>
+  <body class="pure-g">
+    <% if notice %>
+      <div class="notice">
+        <%= notice %>
+      </div>
+    <% end %>
+    <% if alert %>
+      <div class="alert">
+      <%= alert %>
+      </div>
+    <% end %>
+    <%= yield %>
+  </body>
+</html>

--- a/app/views/profile/show.html.erb
+++ b/app/views/profile/show.html.erb
@@ -12,10 +12,14 @@
                       rodauth.change_password_route,
                       class: "pure-menu-link" %>
         </li>
-
         <li class="pure-menu-list">
           <%= link_to t("links.change_login"),
                       rodauth.change_login_route,
+                      class: "pure-menu-link" %>
+        </li>
+        <li class="pure-menu-list">
+          <%= link_to t("links.close_account"),
+                      rodauth.close_account_route,
                       class: "pure-menu-link" %>
         </li>
       </ul>

--- a/app/views/profile/show.html.erb
+++ b/app/views/profile/show.html.erb
@@ -1,0 +1,18 @@
+<div class="pure-g">
+  <div class="pure-u-1-3">
+    <div class="pure-menu custom-restricted-width">
+      <ul class="pure-menu-list">
+        <li class="pure-menu-list">
+          <%= link_to t("links.remember"),
+                      rodauth.remember_route,
+                      class: "pure-menu-link" %>
+        </li>
+        <li class="pure-menu-list">
+          <%= link_to t("links.change_password"),
+                      rodauth.change_password_route,
+                      class: "pure-menu-link" %>
+        </li>
+      </ul>
+    </div>
+  </div>
+</div>

--- a/app/views/profile/show.html.erb
+++ b/app/views/profile/show.html.erb
@@ -12,6 +12,12 @@
                       rodauth.change_password_route,
                       class: "pure-menu-link" %>
         </li>
+
+        <li class="pure-menu-list">
+          <%= link_to t("links.change_login"),
+                      rodauth.change_login_route,
+                      class: "pure-menu-link" %>
+        </li>
       </ul>
     </div>
   </div>

--- a/app/views/rodauth/_account_form.html.erb
+++ b/app/views/rodauth/_account_form.html.erb
@@ -2,7 +2,7 @@
               method: :post,
               class: "pure-form pure-form-stacked",
               data: { turbo: false } do |form| %>
-  <fieldset class="pure-group">
+  <fieldset>
     <%= form.label "login", rodauth.login_label %>
     <%= form.email_field rodauth.login_param,
                          value: params[rodauth.login_param],

--- a/app/views/rodauth/_account_form.html.erb
+++ b/app/views/rodauth/_account_form.html.erb
@@ -1,0 +1,77 @@
+<%= form_with url: rodauth.create_account_path,
+              method: :post,
+              class: "pure-form pure-form-stacked",
+              data: { turbo: false } do |form| %>
+  <fieldset class="pure-group">
+    <%= form.label "login", rodauth.login_label %>
+    <%= form.email_field rodauth.login_param,
+                         value: params[rodauth.login_param],
+                         id: "login",
+                         autocomplete: "email",
+                         required: true,
+                         class: "pure-input-1",
+                         aria: ({ invalid: true,
+                                  describedby: "login_error_message" } if rodauth.field_error(rodauth.login_param)) %>
+    <%= content_tag(:span,
+                    rodauth.field_error(rodauth.login_param),
+                    class: "pure-form-message warning",
+                    id: "login_error_message") if rodauth.field_error(rodauth.login_param) %>
+
+  <% if rodauth.require_login_confirmation? %>
+    <%= form.label "login-confirm",
+                   rodauth.login_confirm_label %>
+    <%= form.email_field rodauth.login_confirm_param,
+                         value: params[rodauth.login_confirm_param],
+                         id: "login-confirm",
+                         autocomplete: "email",
+                         required: true,
+                         class: "pure-input-1",
+                         aria: (
+                          { invalid: true,
+                            describedby: "login-confirm_error_message" } if rodauth.field_error(
+                              rodauth.login_confirm_param)) %>
+    <%= content_tag(:span,
+                    rodauth.field_error(rodauth.login_confirm_param),
+                    class: "pure-form-message warning",
+                    id: "login-confirm_error_message") if rodauth.field_error(rodauth.login_confirm_param) %>
+  <% end %>
+
+  <% if rodauth.create_account_set_password? %>
+    <%= form.label "password", rodauth.password_label, class: "form-label" %>
+    <%= form.password_field rodauth.password_param,
+                            value: "",
+                            id: "password",
+                            autocomplete: rodauth.password_field_autocomplete_value,
+                            required: true,
+                            class: "pure-input-1",
+                            aria: (
+                              { invalid: true,
+                                describedby: "password_error_message" } if rodauth.field_error(
+                                  rodauth.password_param)) %>
+    <%= content_tag(:span,
+                    rodauth.field_error(rodauth.password_param),
+                    class: "pure-form-message warning",
+                    id: "password_error_message") if rodauth.field_error(rodauth.password_param) %>
+
+    <% if rodauth.require_password_confirmation? %>
+      <%= form.label "password-confirm", rodauth.password_confirm_label %>
+      <%= form.password_field rodauth.password_confirm_param,
+                              value: "",
+                              id: "password-confirm",
+                              autocomplete: "new-password",
+                              required: true,
+                              class: "pure-input-1",
+                              aria: (
+                                { invalid: true,
+                                  describedby: "password-confirm_error_message" } if rodauth.field_error(
+                                    rodauth.password_confirm_param)) %>
+      <%= content_tag(:span,
+                      rodauth.field_error(rodauth.password_confirm_param),
+                      class: "pure-form-message warning",
+                      id: "password-confirm_error_message") if rodauth.field_error(rodauth.password_confirm_param) %>
+    <% end %>
+  <% end %>
+  </fieldset>
+
+  <%= form.submit rodauth.create_account_button, class: "pure-button pure-input-1 pure-button-primary" %>
+<% end %>

--- a/app/views/rodauth/_login_form.html.erb
+++ b/app/views/rodauth/_login_form.html.erb
@@ -1,0 +1,52 @@
+<%= form_with(
+      url: rodauth.login_path,
+      method: :post,
+      class: "pure-form pure-form-stacked",
+      data: { turbo: false }) do |form| %>
+  <fieldset class="pure-group">
+    <% if rodauth.skip_login_field_on_login? %>
+      <%= form.label "login", rodauth.login_label %>
+      <%= form.email_field rodauth.login_param,
+                           value: params[rodauth.login_param],
+                           id: "login",
+                           class: "pure-input-1",
+                           readonly: true %>
+    <% else %>
+      <%= form.label "login", rodauth.login_label %>
+      <%= form.email_field rodauth.login_param,
+                           value: params[rodauth.login_param],
+                           id: "login",
+                           autocomplete: rodauth.login_field_autocomplete_value,
+                           class: "pure-input-1",
+                           required: true,
+                           aria: (
+                            { invalid: true,
+                              describedby: "login_error_message" } if rodauth.field_error(rodauth.login_param)) %>
+      <%= content_tag(:span,
+                      rodauth.field_error(rodauth.login_param),
+                      class: "pure-form-message warning",
+                      id: "login_error_message") if rodauth.field_error(rodauth.login_param) %>
+    <% end %>
+
+    <% unless rodauth.skip_password_field_on_login? %>
+      <%= form.label "password", rodauth.password_label %>
+      <%= form.password_field rodauth.password_param,
+                              value: "",
+                              id: "password",
+                              autocomplete: rodauth.password_field_autocomplete_value,
+                              required: true,
+                              class: "pure-input-1",
+                              aria: (
+                                { 
+                                  invalid: true,
+                                  describedby: "password_error_message"
+                                } if rodauth.field_error(rodauth.password_param)) %>
+      <%= content_tag(:span,
+                      rodauth.field_error(rodauth.password_param),
+                      class: "pure-form-message warning",
+                      id: "password_error_message") if rodauth.field_error(rodauth.password_param) %>
+    <% end %>
+
+  </fieldset>
+  <%= form.submit rodauth.login_button, class: "pure-button pure-input-1 pure-button-primary" %>
+<% end %>

--- a/app/views/rodauth/_login_form_footer.html.erb
+++ b/app/views/rodauth/_login_form_footer.html.erb
@@ -1,0 +1,23 @@
+<% unless rodauth.login_form_footer_links.empty? %>
+  <br>
+  <div class="pure-g text-center">
+    <div class="pure-u-1">
+      <%= link_to rodauth.reset_password_request_link_text, rodauth.reset_password_request_path %>
+    </div>
+  </div>
+  <br>
+  <div class="pure-g">
+    <div class="pure-u-1-2">
+      <%= t(".dont_have_account") %>
+    </div>
+    <div class="pure-u-1-2 text-right">
+      <%= link_to rodauth.create_account_link_text, rodauth.create_account_path, class: "pure-button" %>
+    </div>
+  </div>
+  <br>
+  <div class="pure-g">
+    <div class="pure-u-1">
+      <%= link_to rodauth.verify_account_resend_link_text, rodauth.verify_account_resend_path %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/rodauth/change_login.html.erb
+++ b/app/views/rodauth/change_login.html.erb
@@ -1,0 +1,62 @@
+<%= form_with url: rodauth.change_login_path,
+              method: :post,
+              class: "pure-form pure-form-stacked",
+              data: { turbo: false } do |form| %>
+
+  <fieldset>
+     <legend>
+      <%= rodauth.change_login_page_title %>
+     </legend>
+    <%= form.label "login", rodauth.login_label %>
+    <%= form.email_field rodauth.login_param,
+                         value: params[rodauth.login_param],
+                         id: "login",
+                         autocomplete: "email",
+                         required: true,
+                         class: "pure-input-1",
+                         aria: (
+                          { invalid: true,
+                            describedby: "login_error_message" } if rodauth.field_error(rodauth.login_param)) %>
+    <%= content_tag(:span,
+                    rodauth.field_error(rodauth.login_param),
+                    class: "pure-form-message warning",
+                    id: "login_error_message") if rodauth.field_error(rodauth.login_param) %>
+
+    <% if rodauth.require_login_confirmation? %>
+        <%= form.label "login-confirm", rodauth.login_confirm_label %>
+        <%= form.email_field rodauth.login_confirm_param,
+                             value: params[rodauth.login_confirm_param],
+                             id: "login-confirm",
+                             autocomplete: "email",
+                             required: true,
+                             class: "pure-input-1",
+                             aria: (
+                              { invalid: true,
+                                describedby: "login-confirm_error_message" } if rodauth.field_error(
+                                  rodauth.login_confirm_param)) %>
+        <%= content_tag(:span,
+                        rodauth.field_error(rodauth.login_confirm_param),
+                        class: "pure-form-message warning",
+                        id: "login-confirm_error_message") if rodauth.field_error(rodauth.login_confirm_param) %>
+    <% end %>
+
+    <% if rodauth.change_login_requires_password? %>
+        <%= form.label "password", rodauth.password_label %>
+        <%= form.password_field rodauth.password_param,
+        value: "",
+        id: "password",
+        autocomplete: rodauth.password_field_autocomplete_value,
+        required: true,
+        class: "pure-input-1",
+        aria: (
+          { invalid: true,
+            describedby: "password_error_message" } if rodauth.field_error(rodauth.password_param)) %>
+        <%= content_tag(:span,
+                        rodauth.field_error(rodauth.password_param),
+                        class: "pure-form-message warning",
+                        id: "password_error_message") if rodauth.field_error(rodauth.password_param) %>
+    <% end %>
+  </fieldset>
+
+  <%= form.submit rodauth.change_login_button, class: "pure-button pure-input-1 pure-button-primary" %>
+<% end %>

--- a/app/views/rodauth/change_password.html.erb
+++ b/app/views/rodauth/change_password.html.erb
@@ -1,0 +1,60 @@
+<%= form_with url: rodauth.change_password_path,
+              method: :post,
+              class: "pure-form pure-form-stacked",
+              data: { turbo: false } do |form| %>
+  <fieldset>
+    <% if rodauth.change_password_requires_password? %>
+      <%= form.label "password", rodauth.password_label %>
+      <%= form.password_field rodauth.password_param, 
+                              value: "",
+                              id: "password",
+                              autocomplete: rodauth.password_field_autocomplete_value,
+                              required: true,
+                              class: "pure-input-1",
+                              aria: (
+                                { invalid: true,
+                                  describedby: "password_error_message" } if rodauth.field_error(
+                                    rodauth.password_param)) %>
+      <%= content_tag(:span,
+                      rodauth.field_error(rodauth.password_param),
+                      class: "pure-form-message warning",
+                      id: "password_error_message") if rodauth.field_error(rodauth.password_param) %>
+    <% end %>
+
+    <%= form.label "new-password", rodauth.new_password_label %>
+    <%= form.password_field rodauth.new_password_param,
+                            value: "",
+                            id: "new-password",
+                            autocomplete: "new-password",
+                            required: true,
+                            class: "pure-input-1",
+                            aria: ({ 
+                              invalid: true,
+                              describedby: "new-password_error_message" } if rodauth.field_error(
+                                rodauth.new_password_param)) %>
+    <%= content_tag(:span,
+                    rodauth.field_error(rodauth.new_password_param),
+                    class: "pure-form-message warning",
+                    id: "new-password_error_message") if rodauth.field_error(rodauth.new_password_param) %>
+
+  <% if rodauth.require_password_confirmation? %>
+    <%= form.label "password-confirm", rodauth.password_confirm_label %>
+    <%= form.password_field rodauth.password_confirm_param,
+                            value: "",
+                            id: "password-confirm",
+                            autocomplete: "new-password",
+                            required: true,
+                            class: "pure-input-1",
+                            aria: ({ 
+                              invalid: true,
+                              describedby: "password-confirm_error_message" } if rodauth.field_error(
+                                rodauth.password_confirm_param)) %>
+    <%= content_tag(:span,
+                    rodauth.field_error(rodauth.password_confirm_param),
+                    class: "pure-form-message warning",
+                    id: "password-confirm_error_message") if rodauth.field_error(rodauth.password_confirm_param) %>
+  <% end %>
+  </fieldset>
+
+  <%= form.submit rodauth.change_password_button, class: "pure-button pure-input-1 pure-button-primary" %>
+<% end %>

--- a/app/views/rodauth/close_account.html.erb
+++ b/app/views/rodauth/close_account.html.erb
@@ -1,0 +1,26 @@
+<%= form_with url: rodauth.close_account_path,
+              method: :post,
+              class: "pure-form pure-form-stacked",
+              data: { turbo: false } do |form| %>
+  <fieldset>
+    <% if rodauth.close_account_requires_password? %>
+      <%= form.label "password", rodauth.password_label %>
+      <%= form.password_field rodauth.password_param,
+                              value: "",
+                              id: "password",
+                              autocomplete: rodauth.password_field_autocomplete_value,
+                              required: true,
+                              class: "pure-input-1",
+                              aria: (
+                                { invalid: true,
+                                  describedby: "password_error_message" } if rodauth.field_error(
+                                    rodauth.password_param)) %>
+      <%= content_tag(:span,
+                      rodauth.field_error(rodauth.password_param),
+                      class: "pure-form-message warning",
+                      id: "password_error_message") if rodauth.field_error(rodauth.password_param) %>
+    <% end %>
+  </fieldset>
+
+  <%= form.submit rodauth.close_account_button, class: "pure-button pure-input-1 pure-button-primary" %>
+<% end %>

--- a/app/views/rodauth/create_account.html.erb
+++ b/app/views/rodauth/create_account.html.erb
@@ -1,3 +1,1 @@
-<div class="login-content">
-  <%= render "account_form" %>
-</div>
+<%= render "account_form" %>

--- a/app/views/rodauth/create_account.html.erb
+++ b/app/views/rodauth/create_account.html.erb
@@ -1,0 +1,3 @@
+<div class="login-content">
+  <%= render "account_form" %>
+</div>

--- a/app/views/rodauth/login.html.erb
+++ b/app/views/rodauth/login.html.erb
@@ -1,7 +1,5 @@
-<div class="login-content">
-  <h2 class="text-center">
-    <%= rodauth.login_page_title %>
-  </h2>
-  <%= render "login_form" %>
-  <%== rodauth.login_form_footer %>
-</div>
+<h2 class="text-center">
+  <%= rodauth.login_page_title %>
+</h2>
+<%= render "login_form" %>
+<%== rodauth.login_form_footer %>

--- a/app/views/rodauth/login.html.erb
+++ b/app/views/rodauth/login.html.erb
@@ -1,0 +1,7 @@
+<div class="login-content">
+  <h2 class="text-center">
+    <%= rodauth.login_page_title %>
+  </h2>
+  <%= render "login_form" %>
+  <%== rodauth.login_form_footer %>
+</div>

--- a/app/views/rodauth/logout.html.erb
+++ b/app/views/rodauth/logout.html.erb
@@ -1,0 +1,21 @@
+<%= form_with url: rodauth.logout_path,
+              method: :post,
+              class: "pure-form pure-form-stacked",
+              data: { turbo: false } do |form| %>
+  <fieldset>
+    <% if rodauth.features.include?(:active_sessions) %>
+      <div class="form-check">
+        <%= form.label "global-logout",
+                       rodauth.global_logout_label,
+                       class: "pure-check_box" do %>
+          <%= form.check_box rodauth.global_logout_param,
+                             id: "global-logout",
+                             class: "form-check-input",
+                             include_hidden: false %>
+        <% end %>
+      </div>
+    <% end %>
+  </fieldset>
+
+  <%= form.submit rodauth.logout_button, class: "pure-button pure-input-1 pure-button-primary" %>
+<% end %>

--- a/app/views/rodauth/remember.html.erb
+++ b/app/views/rodauth/remember.html.erb
@@ -1,0 +1,32 @@
+<%= form_with url: rodauth.remember_path,
+              method: :post,
+              class: "pure-form pure-form-stacked",
+              data: { turbo: false } do |form| %>
+  <fieldset>
+    <legend>
+      <%= rodauth.remember_page_title %>
+    </legend>
+    <%= form.label "remember-remember", class: "pure-radio" do %>
+      <%= form.radio_button rodauth.remember_param,
+                            rodauth.remember_remember_param_value,
+                            id: "remember-remember" %>
+        <%= rodauth.remember_remember_label %>
+    <% end %>
+
+    <%= form.label "remember-forget", class: "pure-radio" do %>
+      <%= form.radio_button rodauth.remember_param,
+                            rodauth.remember_forget_param_value,
+                            id: "remember-forget" %>
+        <%= rodauth.remember_forget_label %>
+    <% end %>
+
+    <%= form.label "remember-disable", class: "pure-radio" do %>
+      <%= form.radio_button rodauth.remember_param,
+                            rodauth.remember_disable_param_value,
+                            id: "remember-disable" %>
+      <%= rodauth.remember_disable_label %>
+    <% end %>
+  </fieldset>
+
+  <%= form.submit rodauth.remember_button, class: "pure-button pure-input-1 pure-button-primary" %>
+<% end %>

--- a/app/views/rodauth/reset_password.html.erb
+++ b/app/views/rodauth/reset_password.html.erb
@@ -1,0 +1,42 @@
+<%= form_with url: rodauth.reset_password_path,
+              method: :post,
+              class: "pure-form pure-form-stacked",
+              data: { turbo: false } do |form| %>
+  <fieldset>
+    <%= form.label "password", rodauth.password_label %>
+    <%= form.password_field rodauth.password_param,
+                            value: "",
+                            id: "password",
+                            autocomplete: rodauth.password_field_autocomplete_value,
+                            required: true,
+                            class: "pure-input-1",
+                            aria: (
+                              { invalid: true,
+                                describedby: "password_error_message" } if rodauth.field_error(
+                                  rodauth.password_param)) %>
+    <%= content_tag(:span,
+                    rodauth.field_error(rodauth.password_param),
+                    class: "pure-form-message warning",
+                    id: "password_error_message") if rodauth.field_error(rodauth.password_param) %>
+
+    <% if rodauth.require_password_confirmation? %>
+      <%= form.label "password-confirm", rodauth.password_confirm_label %>
+      <%= form.password_field rodauth.password_confirm_param,
+                              value: "",
+                              id: "password-confirm",
+                              autocomplete: "new-password",
+                              class: "pure-input-1",
+                              required: true,
+                              aria: (
+                                { invalid: true,
+                                  describedby: "password-confirm_error_message" } if rodauth.field_error(
+                                    rodauth.password_confirm_param)) %>
+      <%= content_tag(:span,
+                      rodauth.field_error(rodauth.password_confirm_param),
+                      class: "pure-form-message warning",
+                      id: "password-confirm_error_message") if rodauth.field_error(rodauth.password_confirm_param) %>
+    <% end %>
+  </fieldset>
+
+  <%= form.submit rodauth.reset_password_button, class: "pure-button pure-input-1 pure-button-primary" %>
+<% end %>

--- a/app/views/rodauth/reset_password_request.html.erb
+++ b/app/views/rodauth/reset_password_request.html.erb
@@ -1,0 +1,32 @@
+<%= form_with url: rodauth.reset_password_request_path,
+              method: :post,
+              class: "pure-form pure-form-stacked",
+              data: { turbo: false } do |form| %>
+  <fieldset>
+    <legend>
+      <p>
+        <%= rodauth.reset_password_explanatory_text %>
+      </p>
+    </legend>
+
+  <% if params[rodauth.login_param] && !rodauth.field_error(rodauth.login_param) %>
+    <%= form.hidden_field rodauth.login_param, value: params[rodauth.login_param] %>
+  <% else %>
+      <%= form.label "login", rodauth.login_label %>
+      <%= form.email_field rodauth.login_param,
+                           value: params[rodauth.login_param],
+                           id: "login",
+                           autocomplete: "email",
+                           required: true,
+                           class: "pure-input-1",
+                           aria: (
+                            { invalid: true,
+                              describedby: "login_error_message" } if rodauth.field_error(rodauth.login_param)) %>
+      <%= content_tag(:span,
+                      rodauth.field_error(rodauth.login_param),
+                      class: "pure-form-message warning",
+                      id: "login_error_message") if rodauth.field_error(rodauth.login_param) %>
+  <% end %>
+  </fieldset>
+  <%= form.submit rodauth.reset_password_request_button, class: "pure-button pure-input-1 pure-button-primary" %>
+<% end %>

--- a/app/views/rodauth/verify_account.html.erb
+++ b/app/views/rodauth/verify_account.html.erb
@@ -1,0 +1,51 @@
+<%= form_with url: rodauth.verify_account_path,
+              method: :post,
+              class: "pure-form pure-form-stacked",
+              data: { turbo: false } do |form| %>
+  <fieldset>
+    <% if rodauth.verify_account_set_password? %>
+      <div class="form-group mb-3">
+        <%= form.label "password",
+                      rodauth.password_label %>
+        <%= form.password_field rodauth.password_param,
+                                value: "",
+                                id: "password",
+                                autocomplete: rodauth.password_field_autocomplete_value,
+                                required: true,
+                                class: "pure-input-1",
+                                aria: (
+                                  { invalid: true,
+                                    describedby: "password_error_message" } if rodauth.field_error(
+                                      rodauth.password_param)) %>
+        <%= content_tag(:span,
+                        rodauth.field_error(rodauth.password_param),
+                        class: "pure-form-message warning",
+                        id: "password_error_message") if rodauth.field_error(rodauth.password_param) %>
+      </div>
+
+      <% if rodauth.require_password_confirmation? %>
+        <div class="form-group mb-3">
+          <%= form.label "password-confirm",
+                        rodauth.password_confirm_label %>
+          <%= form.password_field rodauth.password_confirm_param,
+                                  value: "",
+                                  id: "password-confirm",
+                                  autocomplete: "new-password",
+                                  required: true,
+                                  class: "pure-input-1",
+                                  aria: (
+                                    { invalid: true,
+                                      describedby: "password-confirm_error_message" } if rodauth.field_error(
+                                        rodauth.password_confirm_param)) %>
+          <%= content_tag(:span,
+                          rodauth.field_error(rodauth.password_confirm_param),
+                          class: "pure-form-message warning",
+                          id: "password-confirm_error_message") if rodauth.field_error(
+                            rodauth.password_confirm_param) %>
+        </div>
+      <% end %>
+    <% end %>
+  </fieldset>
+
+  <%= form.submit rodauth.verify_account_button, class: "pure-button pure-input-1 pure-button-primary" %>
+<% end %>

--- a/app/views/rodauth/verify_account_resend.html.erb
+++ b/app/views/rodauth/verify_account_resend.html.erb
@@ -1,0 +1,29 @@
+<%= form_with url: rodauth.verify_account_resend_path,
+              method: :post,
+              class: "pure-form pure-form-stacked",
+              data: { turbo: false } do |form| %>
+  <br>
+  <fieldset>
+    <legend>
+      <%== rodauth.verify_account_resend_explanatory_text %>
+    </legend>
+    <% if params[rodauth.login_param] %>
+      <%= form.hidden_field rodauth.login_param, value: params[rodauth.login_param] %>
+    <% else %>
+      <%= form.label "login", rodauth.login_label %>
+      <%= form.email_field rodauth.login_param,
+                          value: params[rodauth.login_param],
+                          id: "login",
+                          autocomplete: "email",
+                          required: true,
+                          class: "pure-input-1",
+                          aria: ({ invalid: true,
+                                    describedby: "login_error_message" } if rodauth.field_error(rodauth.login_param)) %>
+      <%= content_tag(:span,
+                      rodauth.field_error(rodauth.login_param),
+                      class: "pure-form-message warning",
+                      id: "login_error_message") if rodauth.field_error(rodauth.login_param) %>
+    <% end %>
+  </fieldset>
+  <%= form.submit rodauth.verify_account_resend_button, class: "pure-button pure-input-1 pure-button-primary" %>
+<% end %>

--- a/app/views/rodauth/verify_login_change.html.erb
+++ b/app/views/rodauth/verify_login_change.html.erb
@@ -1,0 +1,7 @@
+<%= form_with url: rodauth.verify_login_change_path,
+              method: :post,
+              class: "pure-form pure-form-stacked",
+              data: { turbo: false } do |form| %>
+  <br>
+  <%= form.submit rodauth.verify_login_change_button, class: "pure-button pure-input-1 pure-button-primary" %>
+<% end %>

--- a/app/views/rodauth_mailer/password_changed.text.erb
+++ b/app/views/rodauth_mailer/password_changed.text.erb
@@ -1,0 +1,2 @@
+Someone (hopefully you) has changed the password for the account
+associated to this email address.

--- a/app/views/rodauth_mailer/reset_password.text.erb
+++ b/app/views/rodauth_mailer/reset_password.text.erb
@@ -1,0 +1,5 @@
+Someone has requested a password reset for the account with this email
+address.  If you did not request a password reset, please ignore this
+message.  If you requested a password reset, please go to
+<%= @rodauth.reset_password_email_link %>
+to reset the password for the account.

--- a/app/views/rodauth_mailer/verify_account.text.erb
+++ b/app/views/rodauth_mailer/verify_account.text.erb
@@ -1,0 +1,4 @@
+Someone has created an account with this email address.  If you did not create
+this account, please ignore this message.  If you created this account, please go to
+<%= @rodauth.verify_account_email_link %>
+to verify the account.

--- a/app/views/rodauth_mailer/verify_login_change.text.erb
+++ b/app/views/rodauth_mailer/verify_login_change.text.erb
@@ -1,0 +1,10 @@
+Someone with an account has requested their login be changed to this email address:
+
+Old email: <%= @account.email %>
+
+New email: <%= @new_email %>
+
+If you did not request this login change, please ignore this message.  If you
+requested this login change, please go to
+<%= @rodauth.verify_login_change_email_link %>
+to verify the login change.

--- a/app/views/shared/_flash.html.erb
+++ b/app/views/shared/_flash.html.erb
@@ -1,0 +1,8 @@
+<% flash.each do |flash_type, message| %>
+  <div
+    class="__message <%= flash_type %>"
+    data-controller="removal"
+    data-action="animationend->removal#remove">
+    <%= message %>
+  </div>
+<% end %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -43,6 +43,8 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
 
+  config.action_mailer.default_url_options = { host: "localhost", port: 3000 }
+
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -38,12 +38,21 @@ Rails.application.configure do
   # Store uploaded files on the local file system (see config/storage.yml for options).
   config.active_storage.service = :local
 
-  # Don't care if the mailer can't send.
-  config.action_mailer.raise_delivery_errors = false
-
   config.action_mailer.perform_caching = false
 
-  config.action_mailer.default_url_options = { host: "localhost", port: 3000 }
+  config.action_mailer.default_url_options = {
+    host: ENV.fetch("HOST"),
+    port: ENV.fetch("PORT", 3000).to_i
+  }
+
+  # Don't care if the mailer can't send.
+  config.action_mailer.raise_delivery_errors = true
+
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = {
+    address: ENV.fetch("SMTP_HOST", "localhost"),
+    port: ENV.fetch("SMTP_PORT", 2525).to_i
+  }
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -41,7 +41,7 @@ Rails.application.configure do
   config.action_mailer.perform_caching = false
 
   config.action_mailer.default_url_options = {
-    host: ENV.fetch("HOST"),
+    host: ENV.fetch("HOST", "localhost"),
     port: ENV.fetch("PORT", 3000).to_i
   }
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -63,4 +63,8 @@ Rails.application.configure do
 
   # Raise error when a before_action's only/except options reference missing actions
   config.action_controller.raise_on_missing_callback_actions = true
+
+  config.action_mailer.default_url_options = {
+    host: ENV.fetch("HOST", "localhost")
+  }
 end

--- a/config/initializers/rodauth.rb
+++ b/config/initializers/rodauth.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+Rodauth::Rails.configure do |config|
+  config.app = "RodauthApp"
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -276,3 +276,4 @@ en:
     remember: Remember Setting
     change_password: Change Password
     change_login: Change Email
+    close_account: Close Account

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -272,3 +272,4 @@ en:
 
   links:
     expenses: expenses
+    profile: Profile

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -247,12 +247,17 @@ en:
       long: "%B %d, %Y %H:%M"
       short: "%d %b %H:%M"
     pm: pm
-  
+
+  # views
   titles:
     expenses: Expenses
   descriptions:
     expenses: TODO
+  rodauth:
+    login_form_footer:
+      dont_have_account: Don't have an account?
 
+  #controllers
   expenses:
     index:
       name: name

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -273,3 +273,6 @@ en:
   links:
     expenses: expenses
     profile: Profile
+    remember: Remember Setting
+    change_password: Change Password
+    

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -275,4 +275,4 @@ en:
     profile: Profile
     remember: Remember Setting
     change_password: Change Password
-    
+    change_login: Change Email

--- a/config/locales/rodauth.en.yml
+++ b/config/locales/rodauth.en.yml
@@ -62,7 +62,7 @@ en:
     reset_password_email_sent_notice_flash: An email has been sent to you with a link to reset the password for your account
     reset_password_email_subject: Reset Password
     reset_password_error_flash: There was an error resetting your password
-    reset_password_explanatory_text: "<p>If you have forgotten your password, you can request a password reset:</p>"
+    reset_password_explanatory_text: "If you have forgotten your password, you can request a password reset:"
     reset_password_notice_flash: Your password has been reset
     reset_password_page_title: Reset Password
     reset_password_request_button: Request Password Reset

--- a/config/locales/rodauth.en.yml
+++ b/config/locales/rodauth.en.yml
@@ -82,7 +82,7 @@ en:
     verify_account_page_title: Verify Account
     verify_account_resend_button: Send Verification Email Again
     verify_account_resend_error_flash: Unable to resend verify account email
-    verify_account_resend_explanatory_text: "<p>If you no longer have the email to verify the account, you can request that it be resent to you:</p>"
+    verify_account_resend_explanatory_text: "If you no longer have the email to verify the account, you can request that it be resent to you:"
     verify_account_resend_link_text: Resend Verify Account Information
     verify_login_change_button: Verify Login Change
     verify_login_change_duplicate_account_error_flash: Unable to change login as there is already an account with the new login

--- a/config/locales/rodauth.en.yml
+++ b/config/locales/rodauth.en.yml
@@ -3,11 +3,11 @@ en:
     already_an_account_with_this_login_message: already an account with this login
     attempt_to_create_unverified_account_error_flash: The account you tried to create is currently awaiting verification
     attempt_to_login_to_unverified_account_error_flash: The account you tried to login with is currently awaiting verification
-    change_login_button: Change Login
+    change_login_button: Change Email
     change_login_error_flash: There was an error changing your login
     change_login_needs_verification_notice_flash: An email has been sent to you with a link to verify your login change
     change_login_notice_flash: Your login has been changed
-    change_login_page_title: Change Login
+    change_login_page_title: Change Email
     change_password_button: Change Password
     change_password_error_flash: There was an error changing your password
     change_password_notice_flash: Your password has been changed
@@ -43,7 +43,7 @@ en:
     no_matching_login_message: no matching login
     no_matching_reset_password_key_error_flash: 'There was an error resetting your password: invalid or expired password reset key'
     no_matching_verify_account_key_error_flash: 'There was an error verifying your account: invalid verify account key'
-    no_matching_verify_login_change_key_error_flash: 'There was an error verifying your login change: invalid verify login change key'
+    no_matching_verify_login_change_key_error_flash: 'There was an error verifying your email change: invalid verify login change key'
     password_changed_email_subject: Password Changed
     password_confirm_label: Confirm %{password_label}
     password_label: Password
@@ -84,9 +84,9 @@ en:
     verify_account_resend_error_flash: Unable to resend verify account email
     verify_account_resend_explanatory_text: "If you no longer have the email to verify the account, you can request that it be resent to you:"
     verify_account_resend_link_text: Resend Verify Account Information
-    verify_login_change_button: Verify Login Change
-    verify_login_change_duplicate_account_error_flash: Unable to change login as there is already an account with the new login
-    verify_login_change_email_subject: Verify Login Change
-    verify_login_change_error_flash: Unable to verify login change
-    verify_login_change_notice_flash: Your login change has been verified
-    verify_login_change_page_title: Verify Login Change
+    verify_login_change_button: Verify Email Change
+    verify_login_change_duplicate_account_error_flash: Unable to change email as there is already an account with the new email
+    verify_login_change_email_subject: Verify Email Change
+    verify_login_change_error_flash: Unable to verify email change
+    verify_login_change_notice_flash: Your email change has been verified
+    verify_login_change_page_title: Verify Email Change

--- a/config/locales/rodauth.en.yml
+++ b/config/locales/rodauth.en.yml
@@ -1,0 +1,92 @@
+en:
+  rodauth:
+    already_an_account_with_this_login_message: already an account with this login
+    attempt_to_create_unverified_account_error_flash: The account you tried to create is currently awaiting verification
+    attempt_to_login_to_unverified_account_error_flash: The account you tried to login with is currently awaiting verification
+    change_login_button: Change Login
+    change_login_error_flash: There was an error changing your login
+    change_login_needs_verification_notice_flash: An email has been sent to you with a link to verify your login change
+    change_login_notice_flash: Your login has been changed
+    change_login_page_title: Change Login
+    change_password_button: Change Password
+    change_password_error_flash: There was an error changing your password
+    change_password_notice_flash: Your password has been changed
+    change_password_page_title: Change Password
+    close_account_button: Close Account
+    close_account_error_flash: There was an error closing your account
+    close_account_notice_flash: Your account has been closed
+    close_account_page_title: Close Account
+    contains_null_byte_message: contains null byte
+    create_account_button: Create Account
+    create_account_error_flash: There was an error creating your account
+    create_account_link_text: Create a New Account
+    create_account_notice_flash: Your account has been created
+    create_account_page_title: Create Account
+    email_subject_prefix: ''
+    input_field_label_suffix: ''
+    invalid_password_message: invalid password
+    login_button: Login
+    login_confirm_label: Confirm %{login_label}
+    login_error_flash: There was an error logging in
+    login_form_footer_links_heading: <h2 class="rodauth-login-form-footer-links-heading">Other Options</h2>
+    login_label: Email
+    login_not_valid_email_message: not a valid email address
+    login_notice_flash: You have been logged in
+    login_page_title: Login
+    logins_do_not_match_message: logins do not match
+    logout_button: Logout
+    logout_notice_flash: You have been logged out
+    logout_page_title: Logout
+    multi_phase_login_page_title: Login
+    need_password_notice_flash: Login recognized, please enter your password
+    new_password_label: New Password
+    no_matching_login_message: no matching login
+    no_matching_reset_password_key_error_flash: 'There was an error resetting your password: invalid or expired password reset key'
+    no_matching_verify_account_key_error_flash: 'There was an error verifying your account: invalid verify account key'
+    no_matching_verify_login_change_key_error_flash: 'There was an error verifying your login change: invalid verify login change key'
+    password_changed_email_subject: Password Changed
+    password_confirm_label: Confirm %{password_label}
+    password_label: Password
+    passwords_do_not_match_message: passwords do not match
+    remember_button: Change Remember Setting
+    remember_disable_label: Disable Remember Me
+    remember_error_flash: There was an error updating your remember setting
+    remember_forget_label: Forget Me
+    remember_notice_flash: Your remember setting has been updated
+    remember_page_title: Change Remember Setting
+    remember_remember_label: Remember Me
+    require_login_error_flash: Please login to continue
+    resend_verify_account_page_title: Resend Verification Email
+    reset_password_button: Reset Password
+    reset_password_email_recently_sent_error_flash: An email has recently been sent to you with a link to reset your password
+    reset_password_email_sent_notice_flash: An email has been sent to you with a link to reset the password for your account
+    reset_password_email_subject: Reset Password
+    reset_password_error_flash: There was an error resetting your password
+    reset_password_explanatory_text: "<p>If you have forgotten your password, you can request a password reset:</p>"
+    reset_password_notice_flash: Your password has been reset
+    reset_password_page_title: Reset Password
+    reset_password_request_button: Request Password Reset
+    reset_password_request_error_flash: There was an error requesting a password reset
+    reset_password_request_link_text: Forgot Password?
+    reset_password_request_page_title: Request Password Reset
+    same_as_current_login_message: same as current login
+    same_as_existing_password_message: invalid password, same as current password
+    unverified_account_message: unverified account, please verify account before logging in
+    unverified_change_login_error_flash: Please verify this account before changing the login
+    verify_account_button: Verify Account
+    verify_account_email_recently_sent_error_flash: An email has recently been sent to you with a link to verify your account
+    verify_account_email_sent_notice_flash: An email has been sent to you with a link to verify your account
+    verify_account_email_subject: Verify Account
+    verify_account_error_flash: Unable to verify account
+    verify_account_notice_flash: Your account has been verified
+    verify_account_page_title: Verify Account
+    verify_account_resend_button: Send Verification Email Again
+    verify_account_resend_error_flash: Unable to resend verify account email
+    verify_account_resend_explanatory_text: "<p>If you no longer have the email to verify the account, you can request that it be resent to you:</p>"
+    verify_account_resend_link_text: Resend Verify Account Information
+    verify_login_change_button: Verify Login Change
+    verify_login_change_duplicate_account_error_flash: Unable to change login as there is already an account with the new login
+    verify_login_change_email_subject: Verify Login Change
+    verify_login_change_error_flash: Unable to verify login change
+    verify_login_change_notice_flash: Your login change has been verified
+    verify_login_change_page_title: Verify Login Change

--- a/config/locales/rodauth.es.yml
+++ b/config/locales/rodauth.es.yml
@@ -1,0 +1,92 @@
+es:
+  rodauth:
+    already_an_account_with_this_login_message: ya existe una cuenta con este login
+    attempt_to_create_unverified_account_error_flash: La cuenta que intentaste crear está a la espera de verificación
+    attempt_to_login_to_unverified_account_error_flash: La cuenta con la que intentaste acceder está a la espera de verificación
+    change_login_button: Modificar Login
+    change_login_error_flash: Hubo un error al modificar su login
+    change_login_needs_verification_notice_flash: Se le ha enviado por email un enlace para verificar su modificación de login
+    change_login_notice_flash: Su login fue modificado
+    change_login_page_title: Modificar Login
+    change_password_button: Modificar contraseña
+    change_password_error_flash: Hubo un error al modificar su contraseña
+    change_password_notice_flash: Tu contraseña fue modificada
+    change_password_page_title: Cambiar Contraseña
+    close_account_button: Cerrar cuenta
+    close_account_error_flash: Hubo un error al cerrar su cuenta
+    close_account_notice_flash: Su cuenta fue cerrada
+    close_account_page_title: Cerrar Cuenta
+    contains_null_byte_message: contiene un byte nulo
+    create_account_button: Crear cuenta
+    create_account_error_flash: Hubo un error al crear su cuenta
+    create_account_link_text: Crea una nueva cuenta
+    create_account_notice_flash: Su cuenta fue creada
+    create_account_page_title: Crear Cuenta
+    email_subject_prefix: ''
+    input_field_label_suffix: ''
+    invalid_password_message: contraseña no válida
+    login_button: Iniciar sesión
+    login_confirm_label: Confirmar %{login_label}
+    login_error_flash: Hubo un error al iniciar la sesión
+    login_form_footer_links_heading: <h2 class="rodauth-login-form-footer-links-heading">Otras Opciones</h2>
+    login_label: Login
+    login_not_valid_email_message: no es una dirección de email válida
+    login_notice_flash: Iniciaste sesión con éxito
+    login_page_title: Iniciar Sesión
+    logins_do_not_match_message: logins no coinciden
+    logout_button: Salir
+    logout_notice_flash: Se ha cerrado la sesión
+    logout_page_title: Cerrar Sesión
+    multi_phase_login_page_title: Login
+    need_password_notice_flash: Login reconocido, por favor, introduzca su contraseña
+    new_password_label: Nueva contraseña
+    no_matching_login_message: sin login correspondiente
+    no_matching_reset_password_key_error_flash: 'Se ha producido un error al restablecer su contraseña: clave de restablecimiento no válida o caducada'
+    no_matching_verify_account_key_error_flash: 'Se ha producido un error al verificar su cuenta: la clave de verificación no es válida'
+    no_matching_verify_login_change_key_error_flash: 'Se ha producido un error al verificar su cambio de login: la clave de verificación no es válida'
+    password_changed_email_subject: Contraseña modificada
+    password_confirm_label: Confirmar %{password_label}
+    password_label: Contraseña
+    passwords_do_not_match_message: contraseñas no coinciden
+    remember_button: Cambiar configuración de "Recuérdame"
+    remember_disable_label: Desactivar "Recuérdame"
+    remember_error_flash: Hubo un error al actualizar la configuración de "Recuérdame"
+    remember_forget_label: Olvídame
+    remember_notice_flash: Se ha actualizado la configuración de "Recuérdame"
+    remember_page_title: Cambiar la configuración de "Recuérdame"
+    remember_remember_label: Recuérdame
+    require_login_error_flash: Inicie sesión para continuar
+    resend_verify_account_page_title: Reenviar el email de verificación
+    reset_password_button: Restablecer contraseña
+    reset_password_email_recently_sent_error_flash: Recientemente se le ha enviado un email con un enlace para restablecer su contraseña
+    reset_password_email_sent_notice_flash: Se le ha enviado un email con un enlace para restablecer la contraseña de su cuenta
+    reset_password_email_subject: Restablecer contraseña
+    reset_password_error_flash: Hubo un error al restablecer su contraseña
+    reset_password_explanatory_text: "<p>Si ha olvidado su contraseña, puede solicitar un restablecimiento:</p>"
+    reset_password_notice_flash: Su contraseña ha sido restablecida
+    reset_password_page_title: Restablecer contraseña
+    reset_password_request_button: Solicitar restablecer la contraseña
+    reset_password_request_error_flash: Se ha producido un error al solicitar el restablecimiento de la contraseña
+    reset_password_request_link_text: "¿Olvidaste la contraseña?"
+    reset_password_request_page_title: Solicitar Restablecer Contraseña
+    same_as_current_login_message: igual al login actual
+    same_as_existing_password_message: contraseña no válida, la misma que la actual
+    unverified_account_message: cuenta no verificada, verifique la cuenta antes de iniciar sesión
+    unverified_change_login_error_flash: Verifique esta cuenta antes de cambiar el inicio de sesión
+    verify_account_button: Verificar cuenta
+    verify_account_email_recently_sent_error_flash: Recientemente se le envió un email con un enlace para verificar su cuenta
+    verify_account_email_sent_notice_flash: Se le ha enviado un email con un enlace para verificar su cuenta
+    verify_account_email_subject: Verificar cuenta
+    verify_account_error_flash: No fue posible verificar la cuenta
+    verify_account_notice_flash: Tu cuenta ha sido verificada
+    verify_account_page_title: Verificar Cuenta
+    verify_account_resend_button: Enviar email de verificación nuevamente
+    verify_account_resend_error_flash: No se puede reenviar el email de la cuenta
+    verify_account_resend_explanatory_text: "<p>Si ya no tienes el email para verificar la cuenta, puedes solicitar que te lo reenvíen:</p>"
+    verify_account_resend_link_text: Reenviar información para verificar cuenta
+    verify_login_change_button: Verificar cambio de login
+    verify_login_change_duplicate_account_error_flash: No se puede cambiar el login porque ya existe una cuenta con el nuevo login
+    verify_login_change_email_subject: Verificar cambio de login
+    verify_login_change_error_flash: No se pudo verificar el cambio de login
+    verify_login_change_notice_flash: Tu cambio de login fue verificado
+    verify_login_change_page_title: Verificar Cambio de Login

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,5 +12,5 @@ Rails.application.routes.draw do
   get "up" => "rails/health#show", as: :rails_health_check
 
   # Defines the root path route ("/")
-  # root "posts#index"
+  root "expenses#index"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
   resources :categories, only: [] do
     resources :subcategories, only: [:index]
   end
+  get "profile" => "profile#show"
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.

--- a/db/migrate/20240119031436_create_rodauth.rb
+++ b/db/migrate/20240119031436_create_rodauth.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+class CreateRodauth < ActiveRecord::Migration[7.1] # :nodoc:
+  def change
+    enable_extension "citext"
+
+    create_table :accounts do |t|
+      t.integer :status, null: false, default: 1
+      t.citext :email, null: false
+      t.index :email, unique: true, where: "status IN (1, 2)"
+      t.string :password_hash
+    end
+
+    # Used by the password reset feature
+    create_table :account_password_reset_keys, id: false do |t|
+      t.bigint :id, primary_key: true
+      t.foreign_key :accounts, column: :id
+      t.string :key, null: false
+      t.datetime :deadline, null: false
+      t.datetime :email_last_sent, null: false, default: -> { "CURRENT_TIMESTAMP" }
+    end
+
+    # Used by the account verification feature
+    create_table :account_verification_keys, id: false do |t|
+      t.bigint :id, primary_key: true
+      t.foreign_key :accounts, column: :id
+      t.string :key, null: false
+      t.datetime :requested_at, null: false, default: -> { "CURRENT_TIMESTAMP" }
+      t.datetime :email_last_sent, null: false, default: -> { "CURRENT_TIMESTAMP" }
+    end
+
+    # Used by the verify login change feature
+    create_table :account_login_change_keys, id: false do |t|
+      t.bigint :id, primary_key: true
+      t.foreign_key :accounts, column: :id
+      t.string :key, null: false
+      t.string :login, null: false
+      t.datetime :deadline, null: false
+    end
+
+    # Used by the remember me feature
+    create_table :account_remember_keys, id: false do |t|
+      t.bigint :id, primary_key: true
+      t.foreign_key :accounts, column: :id
+      t.string :key, null: false
+      t.datetime :deadline, null: false
+    end
+  end
+end

--- a/db/migrate/20240119031436_create_rodauth.rb
+++ b/db/migrate/20240119031436_create_rodauth.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
 class CreateRodauth < ActiveRecord::Migration[7.1] # :nodoc:
-  def change
+  def change # rubocop:disable Metrics/AbcSize
     enable_extension "citext"
 
-    create_table :accounts do |t|
+    create_table :accounts do |t| # rubocop:disable Rails/CreateTableWithTimestamps
       t.integer :status, null: false, default: 1
       t.citext :email, null: false
       t.index :email, unique: true, where: "status IN (1, 2)"
@@ -12,6 +12,7 @@ class CreateRodauth < ActiveRecord::Migration[7.1] # :nodoc:
     end
 
     # Used by the password reset feature
+    # rubocop:disable Rails/DangerousColumnNames
     create_table :account_password_reset_keys, id: false do |t|
       t.bigint :id, primary_key: true
       t.foreign_key :accounts, column: :id
@@ -45,5 +46,6 @@ class CreateRodauth < ActiveRecord::Migration[7.1] # :nodoc:
       t.string :key, null: false
       t.datetime :deadline, null: false
     end
+    # rubocop:enable Rails/DangerousColumnNames
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,40 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_01_13_034507) do
+ActiveRecord::Schema[7.1].define(version: 2024_01_19_031436) do
   # These are extensions that must be enabled in order to support this database
+  enable_extension "citext"
   enable_extension "plpgsql"
+
+  create_table "account_login_change_keys", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "login", null: false
+    t.datetime "deadline", null: false
+  end
+
+  create_table "account_password_reset_keys", force: :cascade do |t|
+    t.string "key", null: false
+    t.datetime "deadline", null: false
+    t.datetime "email_last_sent", default: -> { "CURRENT_TIMESTAMP" }, null: false
+  end
+
+  create_table "account_remember_keys", force: :cascade do |t|
+    t.string "key", null: false
+    t.datetime "deadline", null: false
+  end
+
+  create_table "account_verification_keys", force: :cascade do |t|
+    t.string "key", null: false
+    t.datetime "requested_at", default: -> { "CURRENT_TIMESTAMP" }, null: false
+    t.datetime "email_last_sent", default: -> { "CURRENT_TIMESTAMP" }, null: false
+  end
+
+  create_table "accounts", force: :cascade do |t|
+    t.integer "status", default: 1, null: false
+    t.citext "email", null: false
+    t.string "password_hash"
+    t.index ["email"], name: "index_accounts_on_email", unique: true, where: "(status = ANY (ARRAY[1, 2]))"
+  end
 
   create_table "categories", force: :cascade do |t|
     t.string "name"
@@ -41,4 +72,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_13_034507) do
     t.index ["category_id"], name: "index_subcategories_on_category_id"
   end
 
+  add_foreign_key "account_login_change_keys", "accounts", column: "id"
+  add_foreign_key "account_password_reset_keys", "accounts", column: "id"
+  add_foreign_key "account_remember_keys", "accounts", column: "id"
+  add_foreign_key "account_verification_keys", "accounts", column: "id"
 end

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -4,4 +4,11 @@ require "test_helper"
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   driven_by :selenium, using: :headless_chrome, screen_size: [1400, 1400]
+
+  def login(email: "user@example.com", password: "averysecret")
+    visit "/login"
+    fill_in "login", with: email
+    fill_in "password", with: password
+    click_on "Login"
+  end
 end

--- a/test/factories/account.rb
+++ b/test/factories/account.rb
@@ -8,6 +8,25 @@ FactoryBot.define do
 
     factory :unverified_account do
       status { :unverified }
+
+      trait :expired_grace_period do
+        after(:build) do |account, _context|
+          account.build_verification_key(
+            key: SecureRandom.alphanumeric(10),
+            requested_at: 25.hours.ago,
+            email_last_sent: 25.hours.ago
+          )
+        end
+      end
+
+      trait :within_grace_period do
+        after(:build) do |account, _context|
+          account.build_verification_key(
+            key: SecureRandom.urlsafe_base64(10),
+            requested_at: Time.zone.now
+          )
+        end
+      end
     end
   end
 end

--- a/test/factories/account.rb
+++ b/test/factories/account.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :account do
+    sequence(:email) { "account-#{_1}@example.com" }
+    password { "verysecretpassword" }
+    status { :verified }
+
+    factory :unverified_account do
+      status { :unverified }
+    end
+  end
+end

--- a/test/system/change_email_test.rb
+++ b/test/system/change_email_test.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "application_system_test_case"
+
+class ChangeEmailTest < ApplicationSystemTestCase
+  def teardown
+    ApplicationMailer.deliveries.clear
+  end
+
+  test "a user change email of his account" do
+    account = create(:account)
+
+    login email: account.email, password: account.password
+    visit "/profile"
+    click_on translate!("links.change_login")
+    fill_in "email", with: "a-new-shiny-email@example.com"
+    fill_in "password", with: account.password
+    click_on translate!("rodauth.change_login_button")
+
+    assert_text translate!("rodauth.change_login_needs_verification_notice_flash")
+
+    visit email_link(%r{(/verify-login-change\?key=.+)$}, "a-new-shiny-email@example.com")
+    click_on translate!("rodauth.verify_login_change_button")
+
+    assert_text translate!("rodauth.verify_login_change_notice_flash")
+  end
+end

--- a/test/system/change_passwords_test.rb
+++ b/test/system/change_passwords_test.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "application_system_test_case"
+
+class ChangePasswordsTest < ApplicationSystemTestCase
+  test "user changes password" do
+    account = create(:account)
+
+    login email: account.email, password: account.password
+    visit "/profile"
+    click_on translate!("links.change_password")
+    fill_in "password", with: account.password
+    fill_in "new-password", with: "anewshinypassword"
+    fill_in "password-confirm", with: "anewshinypassword"
+    click_on translate!("rodauth.change_password_button")
+
+    assert_text translate!("rodauth.change_password_notice_flash")
+  end
+end

--- a/test/system/change_passwords_test.rb
+++ b/test/system/change_passwords_test.rb
@@ -3,6 +3,10 @@
 require "application_system_test_case"
 
 class ChangePasswordsTest < ApplicationSystemTestCase
+  def teardown
+    ApplicationMailer.deliveries.clear
+  end
+
   test "user changes password" do
     account = create(:account)
 
@@ -15,5 +19,9 @@ class ChangePasswordsTest < ApplicationSystemTestCase
     click_on translate!("rodauth.change_password_button")
 
     assert_text translate!("rodauth.change_password_notice_flash")
+
+    email = ApplicationMailer.deliveries.last
+
+    assert_equal email.subject, translate!("rodauth.password_changed_email_subject")
   end
 end

--- a/test/system/close_accounts_test.rb
+++ b/test/system/close_accounts_test.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "application_system_test_case"
+
+class CloseAccountsTest < ApplicationSystemTestCase
+  test "a user closes it's account" do
+    account = create(:account)
+
+    login email: account.email, password: account.password
+    visit "/profile"
+    click_on translate!("links.close_account")
+    fill_in "password", with: account.password
+    click_on translate!("rodauth.close_account_button")
+
+    assert_text translate!("rodauth.close_account_notice_flash")
+  end
+end

--- a/test/system/create_account_test.rb
+++ b/test/system/create_account_test.rb
@@ -3,6 +3,10 @@
 require "application_system_test_case"
 
 class CreateAccount < ApplicationSystemTestCase
+  def teardown
+    ApplicationMailer.deliveries.clear
+  end
+
   test "create account" do
     visit "/create-account"
     fill_in "email", with: "user@example.com"

--- a/test/system/create_account_test.rb
+++ b/test/system/create_account_test.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "application_system_test_case"
+
+class CreateAccount < ApplicationSystemTestCase
+  test "create account" do
+    visit "/create-account"
+    fill_in "email", with: "user@example.com"
+    fill_in "password", with: "averysecurepassword"
+    fill_in "password-confirm", with: "averysecurepassword"
+    click_on translate!("rodauth.create_account_button")
+
+    assert_text translate!("rodauth.verify_account_email_sent_notice_flash")
+  end
+
+  test "create account with invalid email" do
+    visit "/create-account"
+    fill_in "email", with: "invalid@email"
+    fill_in "password", with: "averysecurepassword"
+    fill_in "password-confirm", with: "averysecurepassword"
+    click_on translate!("rodauth.create_account_button")
+
+    assert_text translate!("rodauth.create_account_error_flash")
+  end
+end

--- a/test/system/login_password_test.rb
+++ b/test/system/login_password_test.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require "application_system_test_case"
+
+class LoginPasswordTest < ApplicationSystemTestCase
+  test "login" do
+    account = create(:account)
+    visit "/login"
+
+    fill_in "email", with: account.email
+    fill_in "password", with: "verysecretpassword"
+    click_on "Login"
+
+    assert_text "You have been logged in"
+  end
+end

--- a/test/system/remember_test.rb
+++ b/test/system/remember_test.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require "application_system_test_case"
+
+class Remember < ApplicationSystemTestCase
+  test "user sets 'Forget Me' in remember setting" do
+    account = create(:account)
+
+    login email: account.email, password: "verysecretpassword"
+    visit "/remember"
+    choose "remember", option: "forget"
+    click_on translate!("rodauth.remember_button")
+
+    assert_text translate!("rodauth.remember_notice_flash")
+  end
+end

--- a/test/system/reset_passwords_test.rb
+++ b/test/system/reset_passwords_test.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "application_system_test_case"
+
+class ResetPasswordsTest < ApplicationSystemTestCase
+  def teardown
+    ApplicationMailer.deliveries.clear
+  end
+
+  test "user requests a password reset" do
+    account = create(:account)
+
+    visit "/reset-password-request"
+
+    assert_text translate!("rodauth.reset_password_explanatory_text")
+
+    fill_in "email", with: account.email
+    click_on translate!("rodauth.reset_password_request_button")
+
+    assert_text translate!("rodauth.reset_password_email_sent_notice_flash")
+
+    visit email_link(%r{(/reset-password\?key=.+)$}, account.email)
+    fill_in "password", with: "anewsecurepassword"
+    fill_in "password-confirm", with: "anewsecurepassword"
+    click_on translate!("rodauth.reset_password_button")
+
+    assert_text translate!("rodauth.reset_password_notice_flash")
+
+    fill_in "email", with: account.email
+    fill_in "password", with: "anewsecurepassword"
+    click_on translate!("rodauth.login_button")
+
+    assert_text translate!("rodauth.login_notice_flash")
+  end
+end

--- a/test/system/signout_test.rb
+++ b/test/system/signout_test.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "application_system_test_case"
+
+class SignoutTest < ApplicationSystemTestCase
+  test "when user sign outs is redirected to login page" do
+    account = create(:account)
+
+    login(email: account.email, password: account.password)
+    click_on "Logout"
+
+    assert_text "Login"
+  end
+end

--- a/test/system/signout_test.rb
+++ b/test/system/signout_test.rb
@@ -7,8 +7,18 @@ class SignoutTest < ApplicationSystemTestCase
     account = create(:account)
 
     login(email: account.email, password: account.password)
-    click_on "Logout"
+    click_on translate!("rodauth.logout_button")
 
-    assert_text "Login"
+    assert_text translate!("rodauth.login_page_title")
+  end
+
+  test "when user signsout through signt out page" do
+    account = create(:account)
+
+    login email: account.email, password: account.password
+    visit "/logout"
+    click_on translate!("rodauth.logout_button")
+
+    assert_text translate!("rodauth.login_page_title")
   end
 end

--- a/test/system/verify_account_test.rb
+++ b/test/system/verify_account_test.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "application_system_test_case"
+
+class VerifyAccountTest < ApplicationSystemTestCase
+  def teardown
+    ApplicationMailer.deliveries.clear
+  end
+
+  test "login with a unveryfied account after grace period, " do
+    account = create(:unverified_account, :expired_grace_period)
+
+    visit "/login"
+    fill_in "email", with: account.email
+    fill_in "password", with: "verysecretpassword"
+    click_on translate!("rodauth.login_button")
+
+    assert_text translate!("rodauth.attempt_to_login_to_unverified_account_error_flash")
+    assert_text translate!("rodauth.verify_account_resend_explanatory_text")
+
+    click_on translate!("rodauth.verify_account_resend_button")
+    visit email_link(%r{(/verify-account\?key=.+)$}, account.email)
+    click_on translate!("rodauth.verify_account_button")
+
+    assert_text translate!("rodauth.verify_account_notice_flash")
+  end
+
+  test "resend verify account" do
+    account = create(:unverified_account, :expired_grace_period)
+
+    visit "/login"
+    click_on translate!("rodauth.verify_account_resend_link_text")
+    fill_in "email", with: account.email
+    click_on translate!("rodauth.verify_account_resend_button")
+
+    assert_text translate!("rodauth.verify_account_email_sent_notice_flash")
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -14,6 +14,10 @@ module ActiveSupport
       alias describe context
     end
     # Add more helper methods to be used by all tests here...
+
+    def translate!(*, **keyword_args)
+      I18n.t(*, **keyword_args, raise: true)
+    end
   end
 end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -18,6 +18,25 @@ module ActiveSupport
     def translate!(*, **keyword_args)
       I18n.t(*, **keyword_args, raise: true)
     end
+
+    def email_link(regexp, to = "foo@example.com")
+      mail = email_sent(to)
+      link = mail.body.to_s.gsub(/ $/, "")[regexp]
+
+      assert_instance_of String, link
+      link
+    end
+
+    def email_sent(to = "foo@example.com")
+      msgs = ActionMailer::Base.deliveries
+
+      assert_equal(1, msgs.length)
+      email = msgs.first
+
+      assert_equal(to, email.to.first)
+      msgs.clear
+      email
+    end
   end
 end
 


### PR DESCRIPTION
Add account login using rodauth-rails with the following features:
  *  create_account,
  *  verify_account,
  *  verify_account_grace_period,
  *  login,
  *  logout,
  *  remember,
  *  reset_password,
  *  change_password,
  *  change_password_notify,
  *  change_login,
  *   verify_login_change,
  *  close_account,
  *  i18n
 
Adds system test cases for only happy paths.

Features no implemented but would be nice to have.
  *  lockout: lockout accounts in protection for brute force attacks.
  * email_auth: use link send to account email to authenticate.