### PR TITLE
chore: configure good job dashboard

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -111,4 +111,6 @@ Rails.application.configure do
   # ]
   # Skip DNS rebinding protection for the default health check endpoint.
   # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
+
+  config.good_job.on_thread_error = ->(exception) { Rails.error.report(exception) }
 end

--- a/config/initializers/good_job.rb
+++ b/config/initializers/good_job.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+GoodJob::Engine.middleware.use(Rack::Auth::Basic) do |username, password|
+  ActiveSupport::SecurityUtils.secure_compare(ENV.fetch("GOOD_JOB_USERNAME", nil), username) &
+    ActiveSupport::SecurityUtils.secure_compare(ENV.fetch("GOOD_JOB_PASSWORD", nil), password)
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
+  mount GoodJob::Engine => "good_job"
+
   resources :expenses, except: %i[show] do
     get :total_amount, on: :collection
   end


### PR DESCRIPTION
* Mounts good dashboard on `/good_job` path
* Report good jobs errors instead of sending them to the logs.